### PR TITLE
Use drop = FALSE to keep matrix dimensions

### DIFF
--- a/R/bigdist.R
+++ b/R/bigdist.R
@@ -178,11 +178,8 @@ bigdist <- function(mat
 #'   number of rows
 distIndex <- function(i, mat, method, size){
 
-  x <- matrix(mat[i, ], nrow = 1)
-  y <- mat[(i + 1):size, ]
-  if(is.null(dim(y))){
-    y <- matrix(y, nrow = 1)
-  }
+  x <- mat[i, , drop = FALSE]
+  y <- mat[(i + 1):size, , drop = FALSE]
 
   distances      <- unclass(proxy::dist(x, y, method))
   dim(distances) <- NULL


### PR DESCRIPTION
I'll be happy to contribute to your package if you wish to. 
I was always interested in doing something about matrix distances with {bigstatsr} but never had the opportunity to do so (because I don't have this need in my current research).

You might want to add some tests in your package so that I'm sure I don't break your package while suggesting some changes.